### PR TITLE
Add sable support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,18 @@ configurations {
 }
 
 repositories {
+    exclusiveContent { // Sable
+        forRepository {
+            maven {
+                url = "https://maven.ryanhcode.dev/releases"
+                name = "RyanHCode Maven"
+            }
+        }
+        filter {
+            includeGroup("dev.ryanhcode.sable")
+            includeGroup("dev.ryanhcode.sable-companion")
+        }
+    }
     maven {
         url = "https://maven.blamejared.com"
     }
@@ -85,6 +97,12 @@ dependencies {
 
     compileOnly "dev.emi:emi-neoforge:${emi_version}:api"
     localRuntime "dev.emi:emi-neoforge:${emi_version}"
+
+    jarJar(api("dev.ryanhcode.sable-companion:sable-companion-common-${mc_version}:[${sable_companion_version},)")) {
+        version {
+            prefer project.sable_companion_version
+        }
+    }
 }
 
 jar {
@@ -127,7 +145,7 @@ if (System.getenv().CURSEFORGE_KEY) {
     task curseforge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge) {
         apiToken = System.getenv().CURSEFORGE_KEY
 
-        def mainFile = upload(project.curseforge_id, jar)
+        def mainFile = upload(project.curseforge_id, jarJar)
         mainFile.releaseType = 'release'
         mainFile.addModLoader("NeoForge")
         mainFile.addGameVersion("${mc_version}")
@@ -149,7 +167,7 @@ if (System.getenv().MODRINTH_KEY) {
         versionType = "release"
         versionName = "${mod_name} ${mc_version}"
         versionNumber = project.version
-        uploadFile = jar
+        uploadFile = jarJar
         changelog = file("$project.rootDir/changelog.md").text
         gameVersions = ["${mc_version}"]
         loaders = ["neoforge"]

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,4 @@ version=1.3.0
 # Dependencies
 jei_version=19.21.0.247
 emi_version=1.1.22+1.21.1
+sable_companion_version=1.6.0

--- a/src/main/java/mrbysco/constructionstick/basics/StickUtil.java
+++ b/src/main/java/mrbysco/constructionstick/basics/StickUtil.java
@@ -1,5 +1,6 @@
 package mrbysco.constructionstick.basics;
 
+import dev.ryanhcode.sable.companion.SableCompanion;
 import mrbysco.constructionstick.ConstructionStick;
 import mrbysco.constructionstick.api.IStickTemplate;
 import mrbysco.constructionstick.api.IStickUpgrade;
@@ -217,8 +218,21 @@ public class StickUtil {
 		if (!level.mayInteract(player, pos)) return false;
 
 		// Limit range
-		if (ConstructionConfig.MAX_RANGE.get() > 0 &&
-				StickUtil.blockDistance(player.blockPosition(), pos) > ConstructionConfig.MAX_RANGE.get()) return false;
+		int maxRange = ConstructionConfig.MAX_RANGE.get();
+		if (maxRange > 0) {
+			BlockPos playerPos = player.blockPosition();
+			double distance = SableCompanion.INSTANCE.rectilinearDistanceWithSubLevels(
+					level,
+					playerPos.getX() + 0.5,
+					playerPos.getY() + 0.5,
+					playerPos.getZ() + 0.5,
+					pos.getX() + 0.5,
+					pos.getY() + 0.5,
+					pos.getZ() + 0.5);
+			if (distance > maxRange) {
+				return false;
+			}
+		}
 
 		return true;
 	}


### PR DESCRIPTION
This PR adds sable companion for compatibility with sable. Since there is no way in vanilla minecraft to calculate the manhatten distance from an entity, this is needed for compat to work properly.

This fixes https://github.com/ryanhcode/sable/issues/403